### PR TITLE
chore: add commitlint and pre-commit configuration

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+# Run pre-commit autoupdate if you want to manually check for version changes of the hooks used.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -8,6 +9,10 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+  # The commitlint pre-commit hook is installed in the pre-commit stage.
+  # it depends on the conventional commit configuration, which can be
+  # imported as a dependency. The configuration file is required
+  # though to tell commitlint which preset config to use.
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.11.0
     hooks:
@@ -16,3 +21,22 @@ repos:
           - pre-commit
         additional_dependencies:
           - "@commitlint/config-conventional"
+  # Check actions against the Github schema...
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.27.3
+    hooks:
+    #  - id: check-jsonschema # anything else in JSON you can add here
+     - id: check-github-workflows
+
+  # ESLint for NodeJS
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.0.0-alpha.0
+    hooks:
+      - id: eslint
+
+  # There are quite a few pre-commit hooks for golang. I chose this one
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+      - id: go-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.11.0
+    hooks:
+      - id: commitlint
+        stages:
+          - pre-commit
+        additional_dependencies:
+          - "@commitlint/config-conventional"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+This file describes how this project accepts contributions and what the expectations are.
+
+## Pre commit hooks
+
+We use the ["pre-commit" framework](https://pre-commit.com) to manage commit hooks.
+See [`.pre-commit-config.yaml`](.pre-commit-config.yaml) for which hooks are implemented specifically.
+
+Please add these hooks to your clone of the repo by running
+
+``` bash
+pip install pre-commit
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
+
+This should be done _before_ making any commits.
+
+
+## Commit messages
+
+This project follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#specification) message standard, which is enforced by pre-commit hooks (see above).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # krateo-composable-operations
+
 Krateo Composable Operations (KCO)

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};


### PR DESCRIPTION
This adds a [pre-commit](https://pre-commit.com) framework configuration file which uses a commitlint hook to enforce [conventional commits](https://conventionalcommits.org) on commit messages.

I've added a `CONTRIBUTING.md` to explain.